### PR TITLE
Implement access to random number generator

### DIFF
--- a/Ra01S.cpp
+++ b/Ra01S.cpp
@@ -333,6 +333,14 @@ uint8_t SX126x::GetStatus(void)
 }
 
 
+uint32_t SX126x::GetRandomNumber(void)
+{
+  uint8_t random[4];
+  ReadRegister(SX126X_REG_RANDOM_NUMBER_0, random, 4);
+  return *((uint32_t *)random);
+}
+
+
 void SX126x::SetDio3AsTcxoCtrl(float voltage, uint32_t delay)
 {
   uint8_t buf[4];

--- a/Ra01S.h
+++ b/Ra01S.h
@@ -367,14 +367,15 @@ class SX126x {
   public:
     SX126x(int spiSelect, int reset, int busy, int txen = -1, int rxen = -1);
 
-    int16_t begin(uint32_t frequencyInHz, int8_t txPowerInDbm, float tcxoVoltage = 0.0, bool useRegulatorLDO = false);
-    void    LoRaConfig(uint8_t spreadingFactor, uint8_t bandwidth, uint8_t codingRate, uint16_t preambleLength, uint8_t payloadLen, bool crcOn, bool invertIrq);
-    uint8_t Receive(uint8_t *pData, uint16_t len);
-    bool    Send(uint8_t *pData, uint8_t len, uint8_t mode);
-    bool    ReceiveMode(void);
-    void    GetPacketStatus(int8_t *rssiPacket, int8_t *snrPacket);
-    void    SetTxPower(int8_t txPowerInDbm);
-    void    DebugPrint(bool enable);
+    int16_t  begin(uint32_t frequencyInHz, int8_t txPowerInDbm, float tcxoVoltage = 0.0, bool useRegulatorLDO = false);
+    void     LoRaConfig(uint8_t spreadingFactor, uint8_t bandwidth, uint8_t codingRate, uint16_t preambleLength, uint8_t payloadLen, bool crcOn, bool invertIrq);
+    uint8_t  Receive(uint8_t *pData, uint16_t len);
+    bool     Send(uint8_t *pData, uint8_t len, uint8_t mode);
+    bool     ReceiveMode(void);
+    void     GetPacketStatus(int8_t *rssiPacket, int8_t *snrPacket);
+    void     SetTxPower(int8_t txPowerInDbm);
+    uint32_t GetRandomNumber(void);
+    void     DebugPrint(bool enable);
 
 
   private:    


### PR DESCRIPTION
Thanks for this module! I was about to give up getting my Ra-01SH to run when I stumbled upon your repo. All the other libraries gave some sort of error and this saved from having to dive into the datasheet and debugging things myself.

My PR adds a `GetRandomNumber()` function that allows reading a 32-bit random number from the Ra-01's built in random number generator.